### PR TITLE
Fix class names array

### DIFF
--- a/apps/improc/views.py
+++ b/apps/improc/views.py
@@ -56,12 +56,16 @@ def train_neural_network_v2(layers, nodes, act_functions, epochs, dst_path, outp
         if not os.path.exists(checkpoint_path):
             os.makedirs(checkpoint_path)
         checkpoint_full_path = os.path.join(checkpoint_path, 'cp.ckpt')
+        '''
         checkpoint_callback = tf.keras.callbacks.ModelCheckpoint(filepath=checkpoint_full_path,
                                                                  save_weights_only=True,
                                                                  verbose=1)
+        '''
+
         # Loading of the train and testing images and labels
         (train_images, train_labels), (test_images, test_labels) = utils.load_data(dst_path)
         classes = utils.class_names
+        print(utils.class_names)
 
         train_images = train_images / 255.0
         test_images = test_images / 255.0

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -252,6 +252,7 @@ def gzip_all_files_in_dir(path_to_dir):
 
 
 def set_name_classes(path):
+    class_names.clear()
     list_dir = get_subdir(path)
     for label in list_dir:
         dirname = label


### PR DESCRIPTION
Fixed bug that caused class names array to append the classes of all the network trainings. The array is now being cleared before it's filled with the names of the classes in the current training.