### PR TITLE
Export confusion matrix

### DIFF
--- a/apps/improc/templates/improc/load_model.html
+++ b/apps/improc/templates/improc/load_model.html
@@ -67,6 +67,10 @@
             </div>
         </div>
     </div>
+    <div class="col-lg-8 offset-lg-2" style="margin-top: 60px">
+        <div id="confusion_matrix">
+        </div>
+    </div>
 {% endblock %}
 
 {% block js_block %}
@@ -139,7 +143,7 @@
                         success: function (data) {
                             const upload_gif = $("#upload_gif");
                             let json = JSON.parse(data);
-                            let dir_name = json.img_set_name;
+                            let dir_name = json.img_name;
                             let hid_layers = json.hidden_layers;
                             let out_layer = json.output_layer;
                             upload_gif.html('');
@@ -157,7 +161,10 @@
                             //Info about output layer is added to the datatable
                             table.row.add(
                                 ['Output layer', out_layer[0], out_layer[1]]
-                            ).draw()
+                            ).draw();
+                            $('#confusion_matrix').html('<img alt="Confusion matrix" src="/media/' + dir_name + '" ' +
+                            'height="600" width="600">');
+
 
                         },
                         error: function () {

--- a/apps/improc/views.py
+++ b/apps/improc/views.py
@@ -83,7 +83,6 @@ def train_neural_network_v2(layers, nodes, act_functions, epochs, output_act_fun
         model.fit(train_images, train_labels, epochs=epochs)
         utils.save_model_to_json(checkpoint_path, model)
         model.save(os.path.join(checkpoint_path, 'neural_network.h5'))
-        utils.compress_model_folder(dst_path)
         test_loss, test_acc = model.evaluate(test_images, test_labels)
         print('Test accuracy:', test_acc)
 
@@ -108,6 +107,8 @@ def train_neural_network_v2(layers, nodes, act_functions, epochs, output_act_fun
         plt.ylabel('True label')
         plt.xlabel('Predicted label')
         plt.savefig(con_matrix_img_path, format='png', bbox_inches='tight')
+        shutil.copy(con_matrix_img_path, checkpoint_path)
+        utils.compress_model_folder(dst_path)
 
         '''
         con_mat_figure = plt.gcf()
@@ -243,6 +244,7 @@ def load_model(request):
         'elu': 'Exponential Linear Unit',
         'softmax': 'Softmax'
     }
+
     default_storage.save(model_zip.name, model_zip)
     load_dir_name = utils.get_name_for_working_dir(MEDIA_ROOT, action)
     dst_path = os.path.join(MEDIA_ROOT, load_dir_name)
@@ -250,9 +252,10 @@ def load_model(request):
         os.mkdir(dst_path)
 
     utils.file_extraction_manager(MEDIA_ROOT, model_zip, dst_path)
-    extracted_list_dir = os.listdir(dst_path)
-    path_to_json_file = os.path.join(dst_path, extracted_list_dir[0])
-    path_to_model_file = os.path.join(dst_path, extracted_list_dir[1])
+    path_to_conf_matrix = os.path.split(dst_path)[1] + '/conf_matrix.png'
+    path_to_json_file = os.path.join(dst_path, 'json_nn.json')
+    path_to_model_file = os.path.join(dst_path, 'neural_network.h5')
+
     f = open(path_to_json_file, "r")
     f_content = json.loads(f.read())['config']
     f.close()
@@ -261,7 +264,8 @@ def load_model(request):
     result = {
         'num_layers': len_f_content,
         'img_set_name': load_dir_name,
-        'hidden_layers': []
+        'hidden_layers': [],
+        'img_name': path_to_conf_matrix
     }
 
     for i in range(len_f_content):

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -327,4 +327,3 @@ def compress_model_folder(path_to_working_dir):
         folder = root[length:]
         for file in files:
             ziph.write(os.path.join(root, file), os.path.join(folder, file))
-


### PR DESCRIPTION
The following changes were made:

- The confusion matrix obtained in the training and testing of the neural network is now saved in the folder used to save the neural network.

- When the neural network is loaded, the confusion matrix is showed along with the information about the neural network.